### PR TITLE
Fix error on loading this plugin at first time

### DIFF
--- a/autoload/colortuner.vim
+++ b/autoload/colortuner.vim
@@ -14,7 +14,8 @@ function! colortuner#init()
 endfunction
 
 function! colortuner#load()
-  let settings = readfile(expand(g:colortuner_filepath))
+  let file = expand(g:colortuner_filepath)
+  let settings = filereadable(file) ? readfile(file) : []
   if len(settings) == 1
     execute 'let s:settings = '.settings[0]
   else


### PR DESCRIPTION
vim-colortuner throws error with `readfile(expand(g:colortuner_filepath))`
at first time because `g:colortuner_filepath` doesn't exists.

It should see `filereadable()` and then, call `readfile()`.
