### PR TITLE
Yank to work with unamed plus register/Neovim/anyregister

### DIFF
--- a/autoload/colortuner.vim
+++ b/autoload/colortuner.vim
@@ -92,7 +92,10 @@ function! colortuner#rotate_colorscheme(delta)
 endfunction
 
 function! colortuner#yank()
-  let @" = s:current_colors
+  " Will work with any register, and with unamedplus register
+  " e.g. "ayy
+  exe "let @".v:register."='".s:current_colors."'"
+  echom "Colors yanked to register ".v:register
 endfunction
 
 function! s:render()


### PR DESCRIPTION
Great plugin thank you. If one sets `clipboard=unnamedplus` with Neovim the yank function did not work. Further more it currently does not allow one to use any register. The changes address these issues.
E.g. one one can yank all colours to register a with "ayy