### PR TITLE
Save when closing the Colortuner UI instead of when quitting nvim

### DIFF
--- a/autoload/colortuner.vim
+++ b/autoload/colortuner.vim
@@ -9,7 +9,7 @@ function! colortuner#init()
     autocmd ColorScheme,VimEnter * call colortuner#on_colorscheme()
     autocmd VimEnter * call colortuner#get_all_colorschemes()
     autocmd BufEnter __colortuner__ call colortuner#ui#setup()
-    autocmd VimLeave * call colortuner#save()
+    autocmd BufLeave __colortuner__ call colortuner#save()
   augroup END
 endfunction
 
@@ -24,7 +24,11 @@ function! colortuner#load()
 endfunction
 
 function! colortuner#save()
-  call writefile([string(s:settings)], expand(g:colortuner_filepath))
+  try
+    call writefile([string(s:settings)], expand(g:colortuner_filepath))
+  catch
+    echo "Error during colortuner#save " . v:exception
+  endtry
 endfunction
 
 function! colortuner#on_colorscheme()


### PR DESCRIPTION
The plugin wasn't reliably saving changes to the colortuner_filepath for me in Neovim, so I changed to save when closing the Colortuner UI instead. 

I also added a try-catch to the saving function to notify the user if there were any problems saving the settings.